### PR TITLE
Support for usernames with special characters

### DIFF
--- a/FDHmac.java
+++ b/FDHmac.java
@@ -36,7 +36,7 @@ public class FDHmac
     private static String getHMACHash(String name,String email,long timeInMillis) throws Exception {
         byte[] keyBytes = sharedSecret.getBytes();
         String movingFact =name+email+timeInMillis;
-        byte[] text = movingFact.getBytes();
+        byte[] text = movingFact.getBytes("UTF-8");
         
         String hexString = "";
         Mac hmacMD5;


### PR DESCRIPTION
If usernames has special characters it would fail, now with UTF-8 encoding, it works. From support ticket #180262
